### PR TITLE
docs: add python3 server execution command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,10 @@
 
 For manually testing different Ethereum commands.
 
-1. python -m SimpleHTTPServer 8081
+1. Run server
+   - Python 2        
+         python -m SimpleHTTPServer 8081
+   - Python 3      
+         python3 -m http.server 8081
+
 2. Load up http://localhost:8081/request.html


### PR DESCRIPTION
[The SimpleHTTPServer module has been merged into http.server in Python 3](https://docs.python.org/2/library/simplehttpserver.html)